### PR TITLE
Add UserExists method to AuthenticationAgent interface

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -13,6 +13,11 @@ type AuthenticationAgent interface {
 	// is enabled for the user.
 	Authenticate(ctx context.Context, username, password string) (*AuthSession, error)
 
+	// UserExists checks if a user exists without authenticating.
+	// Returns true if the user exists, false otherwise.
+	// Returns an error only for backend failures, not for missing users.
+	UserExists(ctx context.Context, username string) (bool, error)
+
 	// Close releases any resources held by the agent.
 	Close() error
 }

--- a/passwd/passwd.go
+++ b/passwd/passwd.go
@@ -162,6 +162,15 @@ func (a *Agent) Close() error {
 	return nil
 }
 
+// UserExists checks if a user exists without authenticating.
+func (a *Agent) UserExists(ctx context.Context, username string) (bool, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	_, exists := a.users[username]
+	return exists, nil
+}
+
 // GetPublicKey returns the public key for a user.
 func (a *Agent) GetPublicKey(ctx context.Context, username string) ([]byte, error) {
 	a.mu.RLock()


### PR DESCRIPTION
Add UserExists(ctx, username) method to allow checking if a user exists without requiring authentication. This is needed by smtpd to validate recipient addresses during RCPT TO command processing.

The passwd agent implements this by checking its cached user entries map.

Related: https://github.com/infodancer/smtpd/issues/41