### PR TITLE
Add UserExists method and domain package

### DIFF
--- a/domain/config.go
+++ b/domain/config.go
@@ -1,0 +1,56 @@
+package domain
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// DomainConfig is the per-domain configuration structure.
+type DomainConfig struct {
+	Auth     DomainAuthConfig     `toml:"auth"`
+	MsgStore DomainMsgStoreConfig `toml:"msgstore"`
+}
+
+// DomainAuthConfig holds authentication settings for a domain.
+type DomainAuthConfig struct {
+	// Type is the auth agent type (e.g., "passwd", "ldap").
+	Type string `toml:"type"`
+
+	// CredentialBackend is the path to credential storage (relative to domain dir).
+	CredentialBackend string `toml:"credential_backend"`
+
+	// KeyBackend is the path to key storage (relative to domain dir).
+	KeyBackend string `toml:"key_backend"`
+
+	// Options contains backend-specific settings.
+	Options map[string]string `toml:"options"`
+}
+
+// DomainMsgStoreConfig holds message storage settings for a domain.
+type DomainMsgStoreConfig struct {
+	// Type is the store type (e.g., "maildir").
+	Type string `toml:"type"`
+
+	// BasePath is the base directory for storage (relative to domain dir).
+	BasePath string `toml:"base_path"`
+
+	// Options contains backend-specific settings.
+	Options map[string]string `toml:"options"`
+}
+
+// LoadDomainConfig reads and parses a domain configuration file.
+func LoadDomainConfig(path string) (*DomainConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read config: %w", err)
+	}
+
+	var cfg DomainConfig
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parse config: %w", err)
+	}
+
+	return &cfg, nil
+}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1,0 +1,42 @@
+// Package domain provides domain configuration and management for mail services.
+// Each email domain has its own authentication agent and message storage.
+package domain
+
+import (
+	"errors"
+
+	"github.com/infodancer/auth"
+	"github.com/infodancer/msgstore"
+)
+
+// Domain holds the configuration and agents for a single email domain.
+type Domain struct {
+	// Name is the domain name (e.g., "example.com").
+	Name string
+
+	// AuthAgent handles user authentication and existence checks for this domain.
+	AuthAgent auth.AuthenticationAgent
+
+	// DeliveryAgent handles message storage for this domain.
+	DeliveryAgent msgstore.DeliveryAgent
+}
+
+// Close releases resources held by the domain's agents.
+func (d *Domain) Close() error {
+	var errs []error
+
+	if d.AuthAgent != nil {
+		if err := d.AuthAgent.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	// DeliveryAgent (MsgStore) may have Close() - check if it implements io.Closer
+	if closer, ok := d.DeliveryAgent.(interface{ Close() error }); ok {
+		if err := closer.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/domain/filesystem.go
+++ b/domain/filesystem.go
@@ -1,0 +1,169 @@
+package domain
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/infodancer/auth"
+	"github.com/infodancer/msgstore"
+)
+
+// FilesystemDomainProvider loads domain configs from a directory structure.
+// Each domain has its own subdirectory containing a config.toml file.
+//
+// Directory structure:
+//
+//	/etc/mail/domains/
+//	├── example.com/
+//	│   └── config.toml
+//	├── other.org/
+//	│   └── config.toml
+type FilesystemDomainProvider struct {
+	basePath string
+	cache    map[string]*Domain
+	mu       sync.RWMutex
+	logger   *slog.Logger
+}
+
+// NewFilesystemDomainProvider creates a new filesystem-based domain provider.
+func NewFilesystemDomainProvider(basePath string, logger *slog.Logger) *FilesystemDomainProvider {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FilesystemDomainProvider{
+		basePath: basePath,
+		cache:    make(map[string]*Domain),
+		logger:   logger,
+	}
+}
+
+// GetDomain returns the Domain for a given domain name.
+// Returns nil if the domain is not handled.
+func (p *FilesystemDomainProvider) GetDomain(name string) *Domain {
+	name = strings.ToLower(name)
+
+	// Check cache first
+	p.mu.RLock()
+	if domain, ok := p.cache[name]; ok {
+		p.mu.RUnlock()
+		return domain
+	}
+	p.mu.RUnlock()
+
+	// Check if domain directory exists
+	domainPath := filepath.Join(p.basePath, name)
+	configPath := filepath.Join(domainPath, "config.toml")
+
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil // Domain not handled
+	}
+
+	// Load config and create Domain
+	domain, err := p.loadDomain(name, domainPath, configPath)
+	if err != nil {
+		p.logger.Error("failed to load domain",
+			slog.String("domain", name),
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	// Cache for future use
+	p.mu.Lock()
+	// Double-check in case another goroutine loaded it
+	if existing, ok := p.cache[name]; ok {
+		p.mu.Unlock()
+		// Clean up the one we just created
+		_ = domain.Close()
+		return existing
+	}
+	p.cache[name] = domain
+	p.mu.Unlock()
+
+	return domain
+}
+
+// loadDomain loads a domain configuration and creates the domain agents.
+func (p *FilesystemDomainProvider) loadDomain(name, domainPath, configPath string) (*Domain, error) {
+	// Load config.toml
+	cfg, err := LoadDomainConfig(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("load config: %w", err)
+	}
+
+	// Create auth agent (paths relative to domainPath)
+	authCfg := auth.AuthAgentConfig{
+		Type:              cfg.Auth.Type,
+		CredentialBackend: filepath.Join(domainPath, cfg.Auth.CredentialBackend),
+		KeyBackend:        filepath.Join(domainPath, cfg.Auth.KeyBackend),
+		Options:           cfg.Auth.Options,
+	}
+	authAgent, err := auth.OpenAuthAgent(authCfg)
+	if err != nil {
+		return nil, fmt.Errorf("create auth agent: %w", err)
+	}
+
+	// Create message store (paths relative to domainPath)
+	storeCfg := msgstore.StoreConfig{
+		Type:     cfg.MsgStore.Type,
+		BasePath: filepath.Join(domainPath, cfg.MsgStore.BasePath),
+		Options:  cfg.MsgStore.Options,
+	}
+	store, err := msgstore.Open(storeCfg)
+	if err != nil {
+		_ = authAgent.Close()
+		return nil, fmt.Errorf("create msgstore: %w", err)
+	}
+
+	p.logger.Debug("loaded domain",
+		slog.String("domain", name),
+		slog.String("auth_type", cfg.Auth.Type),
+		slog.String("store_type", cfg.MsgStore.Type))
+
+	return &Domain{
+		Name:          name,
+		AuthAgent:     authAgent,
+		DeliveryAgent: store,
+	}, nil
+}
+
+// Domains returns the list of domain names handled by this provider.
+func (p *FilesystemDomainProvider) Domains() []string {
+	entries, err := os.ReadDir(p.basePath)
+	if err != nil {
+		p.logger.Debug("failed to read domains directory",
+			slog.String("path", p.basePath),
+			slog.String("error", err.Error()))
+		return nil
+	}
+
+	var domains []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			configPath := filepath.Join(p.basePath, entry.Name(), "config.toml")
+			if _, err := os.Stat(configPath); err == nil {
+				domains = append(domains, entry.Name())
+			}
+		}
+	}
+	return domains
+}
+
+// Close releases resources for all loaded domains.
+func (p *FilesystemDomainProvider) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var errs []error
+	for name, domain := range p.cache {
+		if err := domain.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("close domain %s: %w", name, err))
+		}
+	}
+	p.cache = make(map[string]*Domain)
+	return errors.Join(errs...)
+}

--- a/domain/filesystem_test.go
+++ b/domain/filesystem_test.go
@@ -1,0 +1,231 @@
+package domain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/infodancer/auth/passwd"
+	_ "github.com/infodancer/msgstore/maildir"
+)
+
+func TestFilesystemDomainProvider_GetDomain(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+
+	// Create a domain directory with config
+	domainDir := filepath.Join(tmpDir, "example.com")
+	if err := os.MkdirAll(domainDir, 0755); err != nil {
+		t.Fatalf("failed to create domain dir: %v", err)
+	}
+
+	// Create passwd file
+	passwdPath := filepath.Join(domainDir, "passwd")
+	passwdContent := "testuser:$argon2id$v=19$m=65536,t=3,p=4$c2FsdHNhbHRzYWx0c2FsdA$qqSCqQPLbO7RKU/qFwvGng:testuser\n"
+	if err := os.WriteFile(passwdPath, []byte(passwdContent), 0644); err != nil {
+		t.Fatalf("failed to create passwd file: %v", err)
+	}
+
+	// Create keys directory
+	keysDir := filepath.Join(domainDir, "keys")
+	if err := os.MkdirAll(keysDir, 0755); err != nil {
+		t.Fatalf("failed to create keys dir: %v", err)
+	}
+
+	// Create maildir
+	maildirPath := filepath.Join(domainDir, "maildir")
+	if err := os.MkdirAll(maildirPath, 0755); err != nil {
+		t.Fatalf("failed to create maildir: %v", err)
+	}
+
+	// Create domain config
+	configPath := filepath.Join(domainDir, "config.toml")
+	configContent := `[auth]
+type = "passwd"
+credential_backend = "passwd"
+key_backend = "keys"
+
+[msgstore]
+type = "maildir"
+base_path = "maildir"
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	// Create provider
+	provider := NewFilesystemDomainProvider(tmpDir, nil)
+	defer func() {
+		if err := provider.Close(); err != nil {
+			t.Errorf("failed to close provider: %v", err)
+		}
+	}()
+
+	// Test GetDomain for existing domain
+	d := provider.GetDomain("example.com")
+	if d == nil {
+		t.Fatal("expected domain to be found")
+	}
+	if d.Name != "example.com" {
+		t.Errorf("expected domain name 'example.com', got %q", d.Name)
+	}
+	if d.AuthAgent == nil {
+		t.Error("expected AuthAgent to be set")
+	}
+	if d.DeliveryAgent == nil {
+		t.Error("expected DeliveryAgent to be set")
+	}
+
+	// Test UserExists
+	ctx := context.Background()
+	exists, err := d.AuthAgent.UserExists(ctx, "testuser")
+	if err != nil {
+		t.Fatalf("UserExists failed: %v", err)
+	}
+	if !exists {
+		t.Error("expected testuser to exist")
+	}
+
+	exists, err = d.AuthAgent.UserExists(ctx, "nonexistent")
+	if err != nil {
+		t.Fatalf("UserExists failed: %v", err)
+	}
+	if exists {
+		t.Error("expected nonexistent user to not exist")
+	}
+
+	// Test GetDomain for non-existent domain
+	d = provider.GetDomain("nonexistent.com")
+	if d != nil {
+		t.Error("expected nil for non-existent domain")
+	}
+
+	// Test case-insensitivity
+	d = provider.GetDomain("EXAMPLE.COM")
+	if d == nil {
+		t.Error("expected domain lookup to be case-insensitive")
+	}
+}
+
+func TestFilesystemDomainProvider_Domains(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+
+	// Create two domain directories
+	for _, name := range []string{"example.com", "test.org"} {
+		domainDir := filepath.Join(tmpDir, name)
+		if err := os.MkdirAll(domainDir, 0755); err != nil {
+			t.Fatalf("failed to create domain dir: %v", err)
+		}
+		configPath := filepath.Join(domainDir, "config.toml")
+		if err := os.WriteFile(configPath, []byte("[auth]\ntype = \"passwd\"\n"), 0644); err != nil {
+			t.Fatalf("failed to create config: %v", err)
+		}
+	}
+
+	// Create a directory without config (should not be listed)
+	invalidDir := filepath.Join(tmpDir, "invalid")
+	if err := os.MkdirAll(invalidDir, 0755); err != nil {
+		t.Fatalf("failed to create invalid dir: %v", err)
+	}
+
+	// Create provider
+	provider := NewFilesystemDomainProvider(tmpDir, nil)
+	defer func() {
+		if err := provider.Close(); err != nil {
+			t.Errorf("failed to close provider: %v", err)
+		}
+	}()
+
+	// Test Domains
+	domains := provider.Domains()
+	if len(domains) != 2 {
+		t.Errorf("expected 2 domains, got %d", len(domains))
+	}
+
+	// Check that both domains are listed
+	found := make(map[string]bool)
+	for _, d := range domains {
+		found[d] = true
+	}
+	if !found["example.com"] {
+		t.Error("expected example.com in domains list")
+	}
+	if !found["test.org"] {
+		t.Error("expected test.org in domains list")
+	}
+}
+
+func TestFilesystemDomainProvider_Caching(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+	domainDir := filepath.Join(tmpDir, "example.com")
+	if err := os.MkdirAll(domainDir, 0755); err != nil {
+		t.Fatalf("failed to create domain dir: %v", err)
+	}
+
+	// Create minimal config
+	passwdPath := filepath.Join(domainDir, "passwd")
+	if err := os.WriteFile(passwdPath, []byte("user:hash:user\n"), 0644); err != nil {
+		t.Fatalf("failed to create passwd: %v", err)
+	}
+	keysDir := filepath.Join(domainDir, "keys")
+	if err := os.MkdirAll(keysDir, 0755); err != nil {
+		t.Fatalf("failed to create keys dir: %v", err)
+	}
+	maildirPath := filepath.Join(domainDir, "maildir")
+	if err := os.MkdirAll(maildirPath, 0755); err != nil {
+		t.Fatalf("failed to create maildir: %v", err)
+	}
+	configPath := filepath.Join(domainDir, "config.toml")
+	configContent := `[auth]
+type = "passwd"
+credential_backend = "passwd"
+key_backend = "keys"
+
+[msgstore]
+type = "maildir"
+base_path = "maildir"
+`
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("failed to create config: %v", err)
+	}
+
+	provider := NewFilesystemDomainProvider(tmpDir, nil)
+	defer func() {
+		if err := provider.Close(); err != nil {
+			t.Errorf("failed to close provider: %v", err)
+		}
+	}()
+
+	// First call should load the domain
+	d1 := provider.GetDomain("example.com")
+	if d1 == nil {
+		t.Fatal("expected domain to be found")
+	}
+
+	// Second call should return cached domain
+	d2 := provider.GetDomain("example.com")
+	if d2 == nil {
+		t.Fatal("expected domain to be found on second call")
+	}
+
+	// Both should be the same instance (pointer equality)
+	if d1 != d2 {
+		t.Error("expected cached domain to be returned")
+	}
+}
+
+func TestDomain_Close(t *testing.T) {
+	d := &Domain{
+		Name:          "test.com",
+		AuthAgent:     nil,
+		DeliveryAgent: nil,
+	}
+
+	err := d.Close()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/domain/provider.go
+++ b/domain/provider.go
@@ -1,0 +1,14 @@
+package domain
+
+// DomainProvider maps email domains to their authentication configuration.
+type DomainProvider interface {
+	// GetDomain returns the Domain for a given domain name.
+	// Returns nil if the domain is not handled by this server.
+	GetDomain(name string) *Domain
+
+	// Domains returns the list of domain names handled by this provider.
+	Domains() []string
+
+	// Close releases resources for all loaded domains.
+	Close() error
+}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,10 @@ go 1.24.0
 
 toolchain go1.24.4
 
-require golang.org/x/crypto v0.47.0
+require (
+	github.com/infodancer/msgstore v0.0.0-20260119190950-8397c0fa98ca
+	github.com/pelletier/go-toml/v2 v2.2.4
+	golang.org/x/crypto v0.47.0
+)
 
 require golang.org/x/sys v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,7 @@
+github.com/infodancer/msgstore v0.0.0-20260119190950-8397c0fa98ca h1:vFKaO6G7lV9nH9YcCUn3GKCiyy/0ZzRusbefOw/Mve0=
+github.com/infodancer/msgstore v0.0.0-20260119190950-8397c0fa98ca/go.mod h1:rAI37O/GFfseVCrMSVkZPQtLFgAuUctKRkEFAWGlutQ=
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/sys v0.40.0 h1:DBZZqJ2Rkml6QMQsZywtnjnnGvHza6BTfYFWY9kjEWQ=


### PR DESCRIPTION
## Summary
- Add `UserExists(ctx, username)` method to `AuthenticationAgent` interface
- Implement `UserExists` in passwd agent
- Add `domain` package with `DomainProvider` for multi-domain mail configuration
  - `Domain` struct holds `AuthAgent` and `DeliveryAgent` per domain
  - `FilesystemDomainProvider` loads domain configs from directory structure
  - Per-domain TOML configuration for auth and msgstore settings

## Test plan
- [x] Build passes
- [x] Domain package tests pass
- [ ] Verify passwd agent correctly returns true for existing users
- [ ] Verify passwd agent correctly returns false for non-existent users

Related: https://github.com/infodancer/smtpd/issues/41

🤖 Generated with [Claude Code](https://claude.com/claude-code)