### PR TITLE
Add MessageStore field to Domain struct

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -17,8 +17,11 @@ type Domain struct {
 	// AuthAgent handles user authentication and existence checks for this domain.
 	AuthAgent auth.AuthenticationAgent
 
-	// DeliveryAgent handles message storage for this domain.
+	// DeliveryAgent handles message delivery for this domain.
 	DeliveryAgent msgstore.DeliveryAgent
+
+	// MessageStore provides read access to stored messages for this domain.
+	MessageStore msgstore.MessageStore
 }
 
 // Close releases resources held by the domain's agents.

--- a/domain/filesystem.go
+++ b/domain/filesystem.go
@@ -128,6 +128,7 @@ func (p *FilesystemDomainProvider) loadDomain(name, domainPath, configPath strin
 		Name:          name,
 		AuthAgent:     authAgent,
 		DeliveryAgent: store,
+		MessageStore:  store,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary

- Add `MessageStore msgstore.MessageStore` field to `Domain` struct in `domain/domain.go`
- Populate `MessageStore` from the same store object in `loadDomain()` in `domain/filesystem.go`

The underlying `MsgStore` already implements both `DeliveryAgent` and `MessageStore`; this just surfaces the read interface so pop3d and imapd can access domain-specific message stores.

## Test plan

- [x] All existing auth tests pass (`task test`)
- [x] Lint clean (`task lint`)
- [x] No breaking changes - the new field is additive

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)