### PR TITLE
Add AuthRouter for centralized domain-aware auth routing

### DIFF
--- a/domain/router_test.go
+++ b/domain/router_test.go
@@ -1,0 +1,332 @@
+package domain
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/infodancer/auth"
+	autherrors "github.com/infodancer/auth/errors"
+)
+
+// mockAuthAgent implements auth.AuthenticationAgent for testing.
+type mockAuthAgent struct {
+	authenticateFn func(ctx context.Context, username, password string) (*auth.AuthSession, error)
+	userExistsFn   func(ctx context.Context, username string) (bool, error)
+	closed         bool
+}
+
+func (m *mockAuthAgent) Authenticate(ctx context.Context, username, password string) (*auth.AuthSession, error) {
+	if m.authenticateFn != nil {
+		return m.authenticateFn(ctx, username, password)
+	}
+	return nil, autherrors.ErrAuthFailed
+}
+
+func (m *mockAuthAgent) UserExists(ctx context.Context, username string) (bool, error) {
+	if m.userExistsFn != nil {
+		return m.userExistsFn(ctx, username)
+	}
+	return false, nil
+}
+
+func (m *mockAuthAgent) Close() error {
+	m.closed = true
+	return nil
+}
+
+// mockDomainProvider implements DomainProvider for testing.
+type mockDomainProvider struct {
+	domains map[string]*Domain
+}
+
+func (m *mockDomainProvider) GetDomain(name string) *Domain {
+	return m.domains[name]
+}
+
+func (m *mockDomainProvider) Domains() []string {
+	var names []string
+	for name := range m.domains {
+		names = append(names, name)
+	}
+	return names
+}
+
+func (m *mockDomainProvider) Close() error {
+	return nil
+}
+
+func TestSplitUsername(t *testing.T) {
+	tests := []struct {
+		input      string
+		wantLocal  string
+		wantDomain string
+	}{
+		{"user@example.com", "user", "example.com"},
+		{"alice@sub.domain.org", "alice", "sub.domain.org"},
+		{"plainuser", "plainuser", ""},
+		{"", "", ""},
+		{"user@", "user", ""},
+		{"@domain.com", "", "domain.com"},
+		{"user@first@second", "user@first", "second"},
+	}
+
+	for _, tt := range tests {
+		local, domain := SplitUsername(tt.input)
+		if local != tt.wantLocal || domain != tt.wantDomain {
+			t.Errorf("SplitUsername(%q) = (%q, %q), want (%q, %q)",
+				tt.input, local, domain, tt.wantLocal, tt.wantDomain)
+		}
+	}
+}
+
+func TestAuthRouterAuthenticateDomain(t *testing.T) {
+	domainAgent := &mockAuthAgent{
+		authenticateFn: func(_ context.Context, username, password string) (*auth.AuthSession, error) {
+			if username == "alice" && password == "secret" {
+				return &auth.AuthSession{User: &auth.User{Username: "alice"}}, nil
+			}
+			return nil, autherrors.ErrAuthFailed
+		},
+	}
+
+	fallback := &mockAuthAgent{
+		authenticateFn: func(_ context.Context, username, password string) (*auth.AuthSession, error) {
+			return nil, fmt.Errorf("fallback should not be called")
+		},
+	}
+
+	provider := &mockDomainProvider{
+		domains: map[string]*Domain{
+			"example.com": {
+				Name:      "example.com",
+				AuthAgent: domainAgent,
+			},
+		},
+	}
+
+	router := NewAuthRouter(provider, fallback)
+	ctx := context.Background()
+
+	// Successful domain auth
+	result, err := router.AuthenticateWithDomain(ctx, "alice@example.com", "secret")
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Session.User.Username != "alice" {
+		t.Errorf("expected username 'alice', got %q", result.Session.User.Username)
+	}
+	if result.Domain == nil {
+		t.Fatal("expected domain to be set")
+	}
+	if result.Domain.Name != "example.com" {
+		t.Errorf("expected domain 'example.com', got %q", result.Domain.Name)
+	}
+
+	// Failed domain auth (wrong password)
+	_, err = router.AuthenticateWithDomain(ctx, "alice@example.com", "wrong")
+	if err == nil {
+		t.Fatal("expected auth failure")
+	}
+}
+
+func TestAuthRouterAuthenticateFallback(t *testing.T) {
+	fallback := &mockAuthAgent{
+		authenticateFn: func(_ context.Context, username, password string) (*auth.AuthSession, error) {
+			if username == "bob" && password == "pass" {
+				return &auth.AuthSession{User: &auth.User{Username: "bob"}}, nil
+			}
+			return nil, autherrors.ErrAuthFailed
+		},
+	}
+
+	router := NewAuthRouter(nil, fallback)
+	ctx := context.Background()
+
+	// Plain username goes to fallback
+	result, err := router.AuthenticateWithDomain(ctx, "bob", "pass")
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Session.User.Username != "bob" {
+		t.Errorf("expected username 'bob', got %q", result.Session.User.Username)
+	}
+	if result.Domain != nil {
+		t.Error("expected domain to be nil for fallback auth")
+	}
+}
+
+func TestAuthRouterAuthenticateUnknownDomainFallback(t *testing.T) {
+	fallback := &mockAuthAgent{
+		authenticateFn: func(_ context.Context, username, password string) (*auth.AuthSession, error) {
+			// Fallback receives the full username
+			if username == "carol@unknown.com" && password == "pass" {
+				return &auth.AuthSession{User: &auth.User{Username: "carol@unknown.com"}}, nil
+			}
+			return nil, autherrors.ErrAuthFailed
+		},
+	}
+
+	provider := &mockDomainProvider{
+		domains: map[string]*Domain{}, // no domains
+	}
+
+	router := NewAuthRouter(provider, fallback)
+	ctx := context.Background()
+
+	// Unknown domain falls back to global auth with full username
+	result, err := router.AuthenticateWithDomain(ctx, "carol@unknown.com", "pass")
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result.Session.User.Username != "carol@unknown.com" {
+		t.Errorf("expected username 'carol@unknown.com', got %q", result.Session.User.Username)
+	}
+	if result.Domain != nil {
+		t.Error("expected domain to be nil for fallback auth")
+	}
+}
+
+func TestAuthRouterAuthenticateNoProviderNoFallback(t *testing.T) {
+	router := NewAuthRouter(nil, nil)
+	ctx := context.Background()
+
+	_, err := router.AuthenticateWithDomain(ctx, "user@example.com", "pass")
+	if err != autherrors.ErrAuthFailed {
+		t.Errorf("expected ErrAuthFailed, got %v", err)
+	}
+}
+
+func TestAuthRouterAuthenticate(t *testing.T) {
+	// Test that Authenticate() (the AuthenticationAgent interface method)
+	// delegates to AuthenticateWithDomain and returns just the session.
+	fallback := &mockAuthAgent{
+		authenticateFn: func(_ context.Context, username, password string) (*auth.AuthSession, error) {
+			return &auth.AuthSession{User: &auth.User{Username: username}}, nil
+		},
+	}
+
+	router := NewAuthRouter(nil, fallback)
+	ctx := context.Background()
+
+	session, err := router.Authenticate(ctx, "user", "pass")
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if session.User.Username != "user" {
+		t.Errorf("expected username 'user', got %q", session.User.Username)
+	}
+}
+
+func TestAuthRouterUserExistsDomain(t *testing.T) {
+	domainAgent := &mockAuthAgent{
+		userExistsFn: func(_ context.Context, username string) (bool, error) {
+			// Domain agent receives the local part only
+			return username == "dave", nil
+		},
+	}
+
+	provider := &mockDomainProvider{
+		domains: map[string]*Domain{
+			"example.com": {
+				Name:      "example.com",
+				AuthAgent: domainAgent,
+			},
+		},
+	}
+
+	router := NewAuthRouter(provider, nil)
+	ctx := context.Background()
+
+	// User exists in domain
+	exists, err := router.UserExists(ctx, "dave@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected user to exist")
+	}
+
+	// User does not exist in domain
+	exists, err = router.UserExists(ctx, "nobody@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("expected user to not exist")
+	}
+}
+
+func TestAuthRouterUserExistsFallback(t *testing.T) {
+	fallback := &mockAuthAgent{
+		userExistsFn: func(_ context.Context, username string) (bool, error) {
+			// Fallback receives the full username
+			return username == "eve", nil
+		},
+	}
+
+	router := NewAuthRouter(nil, fallback)
+	ctx := context.Background()
+
+	exists, err := router.UserExists(ctx, "eve")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected user to exist")
+	}
+}
+
+func TestAuthRouterUserExistsUnknownDomain(t *testing.T) {
+	fallback := &mockAuthAgent{
+		userExistsFn: func(_ context.Context, username string) (bool, error) {
+			return username == "frank@unknown.com", nil
+		},
+	}
+
+	provider := &mockDomainProvider{
+		domains: map[string]*Domain{},
+	}
+
+	router := NewAuthRouter(provider, fallback)
+	ctx := context.Background()
+
+	exists, err := router.UserExists(ctx, "frank@unknown.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected user to exist via fallback")
+	}
+}
+
+func TestAuthRouterUserExistsNoProviderNoFallback(t *testing.T) {
+	router := NewAuthRouter(nil, nil)
+	ctx := context.Background()
+
+	exists, err := router.UserExists(ctx, "nobody@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("expected user to not exist")
+	}
+}
+
+func TestAuthRouterClose(t *testing.T) {
+	fallback := &mockAuthAgent{}
+	router := NewAuthRouter(nil, fallback)
+
+	err := router.Close()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify fallback was NOT closed (lifecycle managed by caller)
+	if fallback.closed {
+		t.Error("AuthRouter should not close the fallback agent")
+	}
+}
+
+// Verify AuthRouter implements auth.AuthenticationAgent at compile time.
+var _ auth.AuthenticationAgent = (*AuthRouter)(nil)


### PR DESCRIPTION
## Summary

- Adds `AuthRouter` in `auth/domain` package that implements `auth.AuthenticationAgent`
- Centralizes username splitting and domain routing — daemons pass full `user@domain`, router handles the rest
- Provides `AuthenticateWithDomain()` returning `AuthResult` with resolved `Domain` for callers that need domain-specific stores
- Exports `SplitUsername()` helper to eliminate duplicate split logic across daemons
- `AuthRouter.Close()` is a no-op — caller manages lifecycle of wrapped agents

## Test plan

- [x] `TestSplitUsername` — various username formats including edge cases
- [x] `TestAuthRouterAuthenticateDomain` — routes to domain agent with local part
- [x] `TestAuthRouterAuthenticateFallback` — plain username goes to fallback
- [x] `TestAuthRouterAuthenticateUnknownDomainFallback` — unknown domain falls back with full username
- [x] `TestAuthRouterAuthenticateNoProviderNoFallback` — returns ErrAuthFailed
- [x] `TestAuthRouterAuthenticate` — interface method delegates correctly
- [x] `TestAuthRouterUserExists*` — domain routing, fallback, unknown domain, nil providers
- [x] `TestAuthRouterClose` — verifies no-op (doesn't close wrapped agents)
- [x] Compile-time interface check: `var _ auth.AuthenticationAgent = (*AuthRouter)(nil)`

Closes https://github.com/infodancer/auth/issues/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)