### PR TITLE
Add uid to passwd entries and gid to domain config

### DIFF
--- a/domain/config.go
+++ b/domain/config.go
@@ -12,6 +12,10 @@ type DomainConfig struct {
 	Auth     DomainAuthConfig     `toml:"auth"`
 	MsgStore DomainMsgStoreConfig `toml:"msgstore"`
 
+	// Gid is the OS group ID under which mail-session runs for this domain.
+	// 0 means not configured.
+	Gid uint32 `toml:"gid"`
+
 	// Forwards maps localpart to comma-separated forwarding targets.
 	// The special key "*" is a catchall. A nil map means "not set" and allows
 	// the system default forwards to apply. An empty non-nil map (forwards = {})
@@ -50,6 +54,9 @@ type DomainMsgStoreConfig struct {
 // non-zero values from override. Fields absent in override retain the base value.
 func mergeConfig(base, override DomainConfig) DomainConfig {
 	result := base
+	if override.Gid != 0 {
+		result.Gid = override.Gid
+	}
 	if override.Auth.Type != "" {
 		result.Auth.Type = override.Auth.Type
 	}

--- a/domain/config_test.go
+++ b/domain/config_test.go
@@ -1,0 +1,49 @@
+package domain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDomainConfig_GidTOML(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.toml")
+
+	content := `gid = 2001
+
+[auth]
+type = "passwd"
+
+[msgstore]
+type = "maildir"
+base_path = "users"
+`
+	if err := os.WriteFile(configPath, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := LoadDomainConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadDomainConfig: %v", err)
+	}
+	if cfg.Gid != 2001 {
+		t.Errorf("expected Gid 2001, got %d", cfg.Gid)
+	}
+}
+
+func TestMergeConfig_Gid(t *testing.T) {
+	base := DomainConfig{Gid: 1000}
+	override := DomainConfig{Gid: 2001}
+
+	result := mergeConfig(base, override)
+	if result.Gid != 2001 {
+		t.Errorf("expected merged Gid 2001, got %d", result.Gid)
+	}
+
+	// Zero override should not overwrite base
+	result = mergeConfig(base, DomainConfig{})
+	if result.Gid != 1000 {
+		t.Errorf("expected base Gid 1000 retained, got %d", result.Gid)
+	}
+}

--- a/passwd/passwd.go
+++ b/passwd/passwd.go
@@ -40,6 +40,7 @@ type userEntry struct {
 	username string
 	hash     string // Full hash string including algorithm prefix
 	mailbox  string
+	uid      uint32 // 0 = not yet assigned (pre-migration entry)
 }
 
 // Agent implements AuthenticationAgent using a passwd file and key directory.
@@ -97,7 +98,7 @@ func (a *Agent) loadPasswd() error {
 			continue
 		}
 
-		parts := strings.SplitN(line, ":", 3)
+		parts := strings.SplitN(line, ":", 4)
 		if len(parts) < 2 {
 			continue // Invalid line, skip
 		}
@@ -112,6 +113,13 @@ func (a *Agent) loadPasswd() error {
 		} else {
 			// Default mailbox is username
 			entry.mailbox = parts[0]
+		}
+
+		if len(parts) >= 4 && parts[3] != "" {
+			var uid uint64
+			if _, err := fmt.Sscanf(parts[3], "%d", &uid); err == nil {
+				entry.uid = uint32(uid)
+			}
 		}
 
 		a.users[entry.username] = entry


### PR DESCRIPTION
## Summary

- `userEntry` gains `uid uint32`; `loadPasswd` parses the 4th colon-separated field
- `UserInfo` gains `Uid uint32`; `parsePasswd` populates it; `LookupUID` exposes lookup by username
- `DomainConfig` gains `Gid uint32` (`toml:"gid"`); `mergeConfig` propagates non-zero values
- Tests cover `LookupUID`, `ListUsers` uid parsing, and domain `Gid` TOML parsing and merge behaviour

## Test plan

- [ ] `go test ./passwd/...` — `TestLookupUID`, `TestListUsers_WithUID` pass
- [ ] `go test ./domain/...` — `TestDomainConfig_GidTOML`, `TestMergeConfig_Gid` pass
- [ ] `go build ./...` — clean build

Closes https://github.com/infodancer/auth/issues/19

🤖 Generated with [Claude Code](https://claude.com/claude-code)