### PR TITLE
Add DKIM signing key support to domain configuration

### DIFF
--- a/domain/config.go
+++ b/domain/config.go
@@ -11,6 +11,7 @@ import (
 type DomainConfig struct {
 	Auth     DomainAuthConfig     `toml:"auth"`
 	MsgStore DomainMsgStoreConfig `toml:"msgstore"`
+	DKIM     DKIMConfig           `toml:"dkim"`
 
 	// Gid is the OS group ID under which mail-session runs for this domain.
 	// 0 means not configured.
@@ -59,6 +60,16 @@ type DomainMsgStoreConfig struct {
 	Options map[string]string `toml:"options"`
 }
 
+// DKIMConfig holds DKIM signing configuration for a domain.
+type DKIMConfig struct {
+	// Selector is the DKIM selector name (e.g., "default", "sel1").
+	// Published in DNS as selector._domainkey.domain.
+	Selector string `toml:"selector"`
+
+	// PrivateKeyPath is the path to the Ed25519 private key in PEM format.
+	PrivateKeyPath string `toml:"private_key"`
+}
+
 // mergeConfig returns a new DomainConfig with base values overridden by
 // non-zero values from override. Fields absent in override retain the base value.
 func mergeConfig(base, override DomainConfig) DomainConfig {
@@ -92,6 +103,12 @@ func mergeConfig(base, override DomainConfig) DomainConfig {
 	}
 	if len(override.MsgStore.Options) > 0 {
 		result.MsgStore.Options = override.MsgStore.Options
+	}
+	if override.DKIM.Selector != "" {
+		result.DKIM.Selector = override.DKIM.Selector
+	}
+	if override.DKIM.PrivateKeyPath != "" {
+		result.DKIM.PrivateKeyPath = override.DKIM.PrivateKeyPath
 	}
 	return result
 }

--- a/domain/dkim.go
+++ b/domain/dkim.go
@@ -1,0 +1,35 @@
+package domain
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+)
+
+// LoadDKIMKey reads an Ed25519 private key from a PEM file (PKCS8 format).
+func LoadDKIMKey(path string) (crypto.Signer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read DKIM key %s: %w", path, err)
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found in %s", path)
+	}
+
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse DKIM key %s: %w", path, err)
+	}
+
+	edKey, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("DKIM key %s is not Ed25519 (got %T)", path, key)
+	}
+
+	return edKey, nil
+}

--- a/domain/dkim_test.go
+++ b/domain/dkim_test.go
@@ -1,0 +1,70 @@
+package domain
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestKey(t *testing.T) (string, ed25519.PublicKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pemBlock := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: pkcs8,
+	})
+
+	path := filepath.Join(t.TempDir(), "dkim.pem")
+	if err := os.WriteFile(path, pemBlock, 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path, pub
+}
+
+func TestLoadDKIMKey(t *testing.T) {
+	path, wantPub := writeTestKey(t)
+
+	signer, err := LoadDKIMKey(path)
+	if err != nil {
+		t.Fatalf("LoadDKIMKey: %v", err)
+	}
+
+	gotPub, ok := signer.Public().(ed25519.PublicKey)
+	if !ok {
+		t.Fatalf("public key is %T, want ed25519.PublicKey", signer.Public())
+	}
+	if !gotPub.Equal(wantPub) {
+		t.Error("loaded public key does not match generated key")
+	}
+}
+
+func TestLoadDKIMKey_MissingFile(t *testing.T) {
+	_, err := LoadDKIMKey("/nonexistent/path")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestLoadDKIMKey_InvalidPEM(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.pem")
+	if err := os.WriteFile(path, []byte("not a pem file"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadDKIMKey(path)
+	if err == nil {
+		t.Error("expected error for invalid PEM")
+	}
+}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -4,6 +4,7 @@ package domain
 
 import (
 	"context"
+	"crypto"
 	"errors"
 
 	"github.com/infodancer/auth"
@@ -44,6 +45,13 @@ type Domain struct {
 	// "rcpt" = reject at RCPT TO (default); "data" = defer rejection to after DATA.
 	// Empty means use the global default.
 	RecipientRejection string
+
+	// DKIMSelector is the DKIM selector name for DNS lookup.
+	DKIMSelector string
+
+	// DKIMKey is the loaded Ed25519 private key for DKIM signing.
+	// Nil means DKIM is not configured for this domain.
+	DKIMKey crypto.Signer
 }
 
 // Close releases resources held by the domain's agents.

--- a/domain/filesystem.go
+++ b/domain/filesystem.go
@@ -238,14 +238,34 @@ func (p *FilesystemDomainProvider) loadDomain(name, domainPath, configPath strin
 		slog.String("auth_type", cfg.Auth.Type),
 		slog.String("store_type", cfg.MsgStore.Type))
 
-	return &Domain{
+	dom := &Domain{
 		Name:               name,
 		AuthAgent:          finalAuth,
 		DeliveryAgent:      finalDelivery,
 		MessageStore:       store,
 		MaxMessageSize:     cfg.MaxMessageSize,
 		RecipientRejection: cfg.RecipientRejection,
-	}, nil
+	}
+
+	// Load DKIM signing key if configured.
+	if cfg.DKIM.Selector != "" && cfg.DKIM.PrivateKeyPath != "" {
+		keyPath := resolvePath(domainPath, cfg.DKIM.PrivateKeyPath)
+		key, err := LoadDKIMKey(keyPath)
+		if err != nil {
+			p.logger.Warn("failed to load DKIM key",
+				slog.String("domain", name),
+				slog.String("path", keyPath),
+				slog.String("error", err.Error()))
+		} else {
+			dom.DKIMSelector = cfg.DKIM.Selector
+			dom.DKIMKey = key
+			p.logger.Info("DKIM signing enabled",
+				slog.String("domain", name),
+				slog.String("selector", cfg.DKIM.Selector))
+		}
+	}
+
+	return dom, nil
 }
 
 // Domains returns the list of domain names handled by this provider.


### PR DESCRIPTION
## Summary

- Add `DKIMConfig` to `DomainConfig` with `selector` and `private_key` TOML fields
- Add `DKIMSelector` and `DKIMKey` fields to `Domain` struct
- New `LoadDKIMKey()` loads Ed25519 private keys from PEM/PKCS8 files
- `FilesystemDomainProvider.loadDomain()` loads DKIM keys per domain on demand
- Merge logic preserves DKIM config during domain config merging

## Test plan

- [x] `TestLoadDKIMKey` — loads valid Ed25519 PEM key
- [x] `TestLoadDKIMKey_MissingFile` — returns error for missing file
- [x] `TestLoadDKIMKey_InvalidPEM` — returns error for invalid PEM data
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)